### PR TITLE
Adds gesture navigation, including implementing previous slide navigation

### DIFF
--- a/remote/actions/SlideActions.js
+++ b/remote/actions/SlideActions.js
@@ -26,7 +26,14 @@ module.exports = {
     return changeSlide(pairedState, newSlide);
   },
 
-  prevSlide() {},
+  prevSlide(slideState, pairedState) {
+    let newSlide = slideState.currentSlide - 1;
+    if (newSlide < 0 ) {
+      newSlide = slideState.totalSlides - 1;
+    }
+
+    return changeSlide(pairedState, newSlide);
+  },
 
   reset(pairedState) {
     changeSlide(pairedState, 0);

--- a/remote/components/Slide.js
+++ b/remote/components/Slide.js
@@ -1,10 +1,13 @@
-import React, { Component, PropTypes, Text, View } from 'react-native';
+import React, { Component, PanResponder, PropTypes, Text, View } from 'react-native';
 import SlideContent from './SlideContent';
 import Timer from './Timer';
 import styles from './styles';
 
+
 module.exports = class Slide extends Component {
   static propTypes = {
+    onNext: PropTypes.func.isRequired,
+    onPrev: PropTypes.func.isRequired,
     currentSlide: PropTypes.number.isRequired,
     totalSlides: PropTypes.number.isRequired,
     currentSlideHtml: PropTypes.string.isRequired,
@@ -12,17 +15,32 @@ module.exports = class Slide extends Component {
     elapsedTime: PropTypes.number.isRequired
   };
 
+  componentWillMount() {
+    this._panResponder = PanResponder.create({
+      onStartShouldSetPanResponder: (evt, gestureState) => true,
+      onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
+      onMoveShouldSetPanResponder: (evt, gestureState) => true,
+      onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
+      onPanResponderRelease: (evt, gestureState) => {
+        (gestureState.dx < 0 ? this.props.onPrev : this.props.onNext)();
+      }
+    });
+  }
+
   render() {
     return (
       <View style={ styles.slide }>
-        <Text style={ styles.h1 }>
-          { this.props.currentSlide + 1 } / { this.props.totalSlides }
-        </Text>
+        <View {...this._panResponder.panHandlers} >
+          <Text style={ styles.h1 }>
+            { this.props.currentSlide + 1 } / { this.props.totalSlides }
+          </Text>
 
-        <Timer elapsedTime={ this.props.elapsedTime } />
-
+          <Timer elapsedTime={ this.props.elapsedTime } />
+        </View>
         <SlideContent currentSlideHtml={ this.props.currentSlideHtml }
-                      currentSlideNotes={ this.props.currentSlideNotes } />
+                      currentSlideNotes={ this.props.currentSlideNotes }
+                      onNext={ this.props.onNext }
+                      onPrev={ this.props.onPrev } />
       </View>
     );
   }

--- a/remote/components/SlideContent.js
+++ b/remote/components/SlideContent.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes, Text, View, WebView } from 'react-native';
+import React, { Component, PanResponder, PropTypes, Text, View, WebView  } from 'react-native';
 import Toggle from './Toggle';
 import styles from './styles';
 
@@ -9,6 +9,18 @@ module.exports = class SlideContent extends Component {
     this.state = {
       viewIndex: 0
     };
+  }
+
+  componentWillMount() {
+    this._panResponder = PanResponder.create({
+      onStartShouldSetPanResponder: (evt, gestureState) => true,
+      onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
+      onMoveShouldSetPanResponder: (evt, gestureState) => true,
+      onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
+      onPanResponderRelease: (evt, gestureState) => {
+        (gestureState.dx < 0 ? this.props.onPrev : this.props.onNext)();
+      }
+    });
   }
 
   static propTypes = {
@@ -24,7 +36,7 @@ module.exports = class SlideContent extends Component {
         <Toggle labels={ ['slide', 'notes'] }
                 selectedIndex={ this.state.viewIndex }
                 onChange={ this._onViewChange } />
-        <View style={ styles.previewContainer}>
+        <View style={ styles.previewContainer} {...this._panResponder.panHandlers}>
           <WebView key={ html } ref="webView" style={ styles.preview } html={ html } />
         </View>
       </View>

--- a/remote/components/SlideDeck.js
+++ b/remote/components/SlideDeck.js
@@ -4,6 +4,7 @@ import Slide from './Slide';
 import Control from './Control';
 
 module.exports = class SlideDeck extends Component {
+
   static propTypes = {
     currentSlide: PropTypes.number.isRequired,
     totalSlides: PropTypes.number.isRequired,
@@ -31,15 +32,19 @@ module.exports = class SlideDeck extends Component {
     } = this.props;
 
     return (
-      <TouchableOpacity onPress={ onNext } style={ styles.content }>
+      <View style={ styles.content }>
         <Control currentSlide={ this.props.selectedSlide }
                  totalSlides={ this.props.totalSlides }
                  onRePair={ onRePair }
                  onReset={ onReset }
                  onSelectSlide={ onSelectSlide }
                  onSlideEnd={ onSlideEnd }/>
-        <Slide { ...slideProps }/>
-      </TouchableOpacity>
+        <Slide onNext={ onNext }
+               onPrev={ onPrev }
+               { ...slideProps }/>
+      </View >
     );
   }
+
+
 };

--- a/remote/containers/SlideDeckContainer.js
+++ b/remote/containers/SlideDeckContainer.js
@@ -26,6 +26,7 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
     ...dispatchProps,
     ...ownProps,
     onNext: dispatchProps.onNext.bind(null, stateProps.slideState, stateProps.pairedState),
+    onPrev: dispatchProps.onPrev.bind(null, stateProps.slideState, stateProps.pairedState),
     onReset: dispatchProps.onReset.bind(null, stateProps.pairedState),
     onSlideEnd: dispatchProps.onSlideEnd.bind(null, stateProps.pairedState)
   };


### PR DESCRIPTION
This adds basic navigation to the areas of the mobile clients that don't have other controls. One thing missing now is the feedback to the user. I didn't see a way to keep using the TouchableOpacity component along with the PanResponder. So we'll need to add our own feedback to the PanResponder handlers.